### PR TITLE
Fix typos and grammatical errors in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 `mistral-finetune` is a light-weight codebase that enables memory-efficient and performant finetuning of Mistral's models.
 It is based on [LoRA](https://arxiv.org/abs/2106.09685), a training paradigm where most weights are frozen and only 1-2% additional weights in the form of low-rank matrix perturbations are trained. 
 
-For maximum efficiency it is recommended to use a A100 or H100 GPU. The codebase is optimized 
-for multi-GPU-single-node training setups, but for smaller models, such as the 7B a single GPU suffices.
+For maximum efficiency it is recommended to use an A100 or H100 GPU. The codebase is optimized 
+for multi-GPU-single-node training setups, but for smaller models, such as the 7B, a single GPU suffices.
 
 > **Note**
 > 
@@ -76,7 +76,7 @@ You can build two types of data files:
 
 ### _Pretrain_:
 
-Pretrain data correpsodns to plain text data stored in the `"text"` key. E.g:
+Pretrain data corresponds to plain text data stored in the `"text"` key. E.g:
 
 ```jsonl
 {"text": "Text contained in document n°1"}
@@ -143,7 +143,7 @@ Currently two different types of instruction following data are supported:
 
 - _Function calling_: conversational data stored in the `"messages"` key in the form of a list. Each list item is a dictionary containing the `"role"` and `"role"` keys. `"role"` is a string being one of "user", "assistant", "system_prompt", or "tool". The loss will only be computed if "role" == "assistant".
 
-**Note**: In function calling the `"id"` of `"tool_calls"` and the `"tool_call_id"` are randomly generated strings of exactly 9 chars. We recommend to generate this automatically 
+**Note**: In function calling, the `"id"` of `"tool_calls"` and the `"tool_call_id"` are randomly generated strings of exactly 9 chars. We recommend to generate this automatically 
 in a data preparation script as is done [here](https://github.com/mistralai/mistral-finetune/blob/a612d665897a28a3a7c44c98f88e1f7775f81a1d/utils/reformat_data_glaive.py#L74).
 
 E.g.:


### PR DESCRIPTION
**Description of Change:**

| **Original Text**                                  | **Corrected Text**                           | **Reason for Change**                         |
|----------------------------------------------------|----------------------------------------------|----------------------------------------------|
| a A100 or H100 GPU                                 | an A100 or H100 GPU                          | Correct grammatical error (use of "an" before a vowel sound) |
| such as the 7B a single GPU                        | such as the 7B, a single GPU                 | Correct punctuation error (add comma for clarity)            |
| correpsodns                                        | corresponds                                  | Correct typographical error (spelling mistake)              |
| In function calling the `"id"` of                  | In function calling, the `"id"` of           | Correct punctuation error (add comma for clarity)            |