### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ E.g.:
   "messages": [
     {
       "role": "system",
-      "content": "You are an helpful assistant who has access to the following functions to help the user, you can use the functions if needed"
+      "content": "You are a helpful assistant who has access to the following functions to help the user, you can use the functions if needed"
     },
     {
       "role": "user",


### PR DESCRIPTION
The specific correction is from "an helpful assistant" to "a helpful assistant." This modification is necessary for the following reason:

   - The use of "an" before a word beginning with a consonant sound (in this case, "helpful") is grammatically incorrect in English. The correct indefinite article for such words is "a."