### PR TITLE
Fixed typo in TrainArgs class comment

### DIFF
--- a/finetune/args.py
+++ b/finetune/args.py
@@ -64,7 +64,7 @@ class TrainArgs(Serializable):
 
     optim: OptimArgs = field(default_factory=OptimArgs)
     seed: int = 0
-    # Number of steps to accumulate gradients before calling doing an optimizer step.
+    # Number of steps to accumulate gradients before doing an optimizer step.
     num_microbatches: int = 1
 
     seq_len: int = 2048  # Number of tokens per batch per device.


### PR DESCRIPTION
Corrected the comment for num_microbatches in TrainArgs class to remove redundancy. Changed "calling doing an optimizer step" to "doing an optimizer step" for better clarity.