### PR TITLE
fix: correct typo + capitalization in title

### DIFF
--- a/tutorials/mistral_finetune_7b.ipynb
+++ b/tutorials/mistral_finetune_7b.ipynb
@@ -1392,7 +1392,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "# Getting starting fine-tuning Mistral 7B\n",
+        "# Getting Started with Fine-Tuning Mistral 7B\n",
         "\n",
         "This notebook shows you a simple example of how to LoRA finetune Mistral 7B. You can can run this notebook in Google Colab with Pro + account with A100 and 40GB RAM.\n",
         "\n",


### PR DESCRIPTION
Changed "Getting starting fine-tuning Mistral 7B" to "Getting Started with Fine-Tuning Mistral 7B". Corrected "starting" to "started" to fix the verb form, added "with" for grammatical correctness, and capitalized the title for proper title case formatting.