### PR TITLE
fix: Typo in Size Limitation Comment

### DIFF
--- a/utils/validate_data.py
+++ b/utils/validate_data.py
@@ -40,7 +40,7 @@ MIN_NUM_JSONL_LINES = 10
 MAX_NUM_JSONL_LINES = 10_000_000
 
 MIN_BYTES = 1_000
-MAX_BYTES = 10_000_000_000  # rougly 10 GB
+MAX_BYTES = 10_000_000_000  # roughly 10 GB
 
 
 def convert_seconds_to_hms(seconds: float) -> str:


### PR DESCRIPTION
Corrected the typo in the comment regarding the maximum bytes for JSONL files. Changed "rougly" to "roughly" for better clarity and accuracy.