### PR TITLE
fix: verb tense in print statement

### DIFF
--- a/utils/reformat_data.py
+++ b/utils/reformat_data.py
@@ -75,7 +75,7 @@ def reformat_jsonl(input_file):
             if not skip_sample:
                 outfile.write(json.dumps(data) + "\n")
             else:
-                print(f"Skip {idx}th sample")
+                print(f"Skipped {idx}th sample")
 
     os.rename(output_file, input_file)
 


### PR DESCRIPTION
Changed "Skip {idx}th sample" to "Skipped {idx}th sample" for verb tense consistency, clarity, and alignment with standard logging practices.