### PR TITLE
fix: remove repeated word in notebook metadata

### DIFF
--- a/tutorials/mistral_finetune_7b.ipynb
+++ b/tutorials/mistral_finetune_7b.ipynb
@@ -1394,7 +1394,7 @@
       "source": [
         "# Getting Started with Fine-Tuning Mistral 7B\n",
         "\n",
-        "This notebook shows you a simple example of how to LoRA finetune Mistral 7B. You can can run this notebook in Google Colab with Pro + account with A100 and 40GB RAM.\n",
+        "This notebook shows you a simple example of how to LoRA finetune Mistral 7B. You can run this notebook in Google Colab with Pro + account with A100 and 40GB RAM.\n",
         "\n",
         "<a target=\"_blank\" href=\"https://colab.research.google.com/github/mistralai/mistral-finetune/blob/main/tutorials/mistral_finetune_7b.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",


### PR DESCRIPTION
Corrected a repeated word "can" in the phrase "you can can run this notebook" within the notebook metadata section. This change improves readability and accuracy in the notebook instructions.