### PR TITLE
fix: correct spelling of "length" in comments

### DIFF
--- a/tutorials/mistral_finetune_7b.ipynb
+++ b/tutorials/mistral_finetune_7b.ipynb
@@ -2880,7 +2880,7 @@
         "\n",
         "# optim\n",
         "# tokens per training steps = batch_size x num_GPUs x seq_len\n",
-        "# we recommend sequence lentgh of 32768\n",
+        "# we recommend sequence length of 32768\n",
         "# If you run into memory error, you can try reduce the sequence length\n",
         "seq_len: 8192\n",
         "batch_size: 1\n",


### PR DESCRIPTION
Corrected the misspelling "lentgh" to "length" in the comments within the notebook.