### PR TITLE
fix: correct subject-verb agreement in formatting instructions

### DIFF
--- a/tutorials/mistral_finetune_7b.ipynb
+++ b/tutorials/mistral_finetune_7b.ipynb
@@ -1926,7 +1926,7 @@
       "cell_type": "code",
       "source": [
         "# some of the training data doesn't have the right format,\n",
-        "# so we need to reformat the data into the correct format and skip the cases that doesn't have the right format:\n",
+        "# so we need to reformat the data into the correct format and skip the cases that don't have the right format:\n",
         "\n",
         "!python -m utils.reformat_data /content/data/ultrachat_chunk_train.jsonl"
       ],


### PR DESCRIPTION
Corrected the subject-verb agreement error in the sentence "reformat the data into the correct format and skip the cases that *doesn't* have the right format" to "reformat the data into the correct format and skip the cases that *don't* have the right format".