### PR TITLE
fix: typo in mixed precision test comments

### DIFF
--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -125,7 +125,7 @@ def _check_mixed_precision(
 
         downcast_mixed_precision(model.parameters(), param_dtype=param_dtype)
 
-        # ensure that before new forward pass params are downcasted to param dtype
+        # ensure that before new forward pass params are downcast to param dtype
         for param in model.parameters():
             assert param.dtype == param_dtype
             if param.requires_grad:


### PR DESCRIPTION
This commit corrects a typo in the comments of the mixed precision test code. The term "downcasted" has been replaced with the grammatically correct "downcast". This change ensures the comments are accurate and maintain a professional standard.