### PR TITLE
fix: correct article usage for GPU recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 `mistral-finetune` is a light-weight codebase that enables memory-efficient and performant finetuning of Mistral's models.
 It is based on [LoRA](https://arxiv.org/abs/2106.09685), a training paradigm where most weights are frozen and only 1-2% additional weights in the form of low-rank matrix perturbations are trained. 
 
-For maximum efficiency it is recommended to use a A100 or H100 GPU. The codebase is optimized 
+For maximum efficiency it is recommended to use an A100 or H100 GPU. The codebase is optimized 
 for multi-GPU-single-node training setups, but for smaller models, such as the 7B a single GPU suffices.
 
 > **Note**


### PR DESCRIPTION
Corrected the article usage in the README file for GPU recommendation from "a A100 or H100 GPU" to "an A100 or H100 GPU". The article "an" is used before words that start with a vowel sound or a silent 'h'. Since "A100" starts with a vowel sound, "an" is the correct article to use. Although "H100" starts with a consonant sound, "an" is often used for consistency in lists where one item starts with a vowel sound.