### PR TITLE
fix: typo in TrainArgs warning message

### DIFF
--- a/finetune/args.py
+++ b/finetune/args.py
@@ -112,5 +112,5 @@ class TrainArgs(Serializable):
 
         if not self.save_adapters:
             logging.warning(
-                "You have disabled `save_adapters` and are thus merging the trained LoRA checkpoint into the base model upon checkpointing. This might lead to OOM erros - make sure you have enough CPU and GPU memory."
+                "You have disabled `save_adapters` and are thus merging the trained LoRA checkpoint into the base model upon checkpointing. This might lead to OOM errors - make sure you have enough CPU and GPU memory."
             )


### PR DESCRIPTION
Corrected a typo in the warning message of the TrainArgs class. The word "erros" has been changed to "errors" to improve readability and accuracy.