### PR TITLE
fix: typo in get_fsdp_policy docstring

### DIFF
--- a/finetune/wrapped_model.py
+++ b/finetune/wrapped_model.py
@@ -33,7 +33,7 @@ def main_logger_info(message: str) -> None:
 def get_fsdp_policy(is_lora: bool) -> Callable[[torch.nn.Module], bool]:
     """
     This function instantiates the FSDP wrap policy.
-    - Each Transformers block becomes it's own FSDP group so that only a single Transformer block is sharded at a time
+    - Each Transformers block becomes its own FSDP group so that only a single Transformer block is sharded at a time
     - If LoRA is enabled, we additionally create separate FSDP sub-groups for every trainable and non-trainable parameter group
       since this is a requirement for mixed requires_grad=True/False training. See: https://pytorch.org/docs/stable/fsdp.html
     """


### PR DESCRIPTION
Corrected typo in docstring of the get_fsdp_policy function - "it's" to "its" for proper possessive usage.