### PR TITLE
typo: correct "MoEs models" to "MoE models"

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Once the extension has worked, one can fine-tune using the newly created model c
 
 > - What's the best practice of fine-tuning MoEs?
 
-We see a higher degree of performance variance in when fine-tuning MoE models. It's not unusual to find that fine-tuning MoEs models with different seeds can lead to a high variance in performance. We did not observe such a high variance with dense models. Therefore, we suggest running multiple instances of the same fine-tuning process on MoEs models and selecting the one that performs best.
+We see a higher degree of performance variance in when fine-tuning MoE models. It's not unusual to find that fine-tuning MoE models with different seeds can lead to a high variance in performance. We did not observe such a high variance with dense models. Therefore, we suggest running multiple instances of the same fine-tuning process on MoEs models and selecting the one that performs best.
 
 > - How can I determine the number of tokens used during the model training process?
   


### PR DESCRIPTION
Corrected the term "MoEs models" to "MoE models" in the documentation for consistency and grammatical accuracy. The acronym "MoE" stands for "Mixture of Experts" and should be used in its singular form followed by "models" to maintain proper grammatical structure.