### PR TITLE
Validation script fix: conversation error

### DIFF
--- a/finetune/data/tokenize.py
+++ b/finetune/data/tokenize.py
@@ -179,7 +179,6 @@ def build_instruct_sample(data: Dict[str, Any]) -> TrainingInstructSample:
             messages.append(tool_message)
 
     # validate created messages
-    print(messages)
     validator = MistralRequestValidatorV3(ValidationMode.finetuning)
     validator.validate_messages(messages)
     if added_system_message:

--- a/finetune/data/tokenize.py
+++ b/finetune/data/tokenize.py
@@ -181,6 +181,7 @@ def build_instruct_sample(data: Dict[str, Any]) -> TrainingInstructSample:
     # validate created messages
     validator = MistralRequestValidatorV3(ValidationMode.finetuning)
     validator.validate_messages(messages)
+    # after messages validation, remove system prompt
     if added_system_message:
         messages = messages[1:]
     validator._validate_tools(available_tools or [])


### PR DESCRIPTION
When trying to validate a dataset, if the dataset messages only contain 1 system message, followed by 1 assistant message, such  as
```
{
"messages": [
    {"role": "system", "content": "System prompt"}, 
    {"role": "assistant", "content": "Assistant prompt"}
]}
```
the `utils/validate_data.py` script results in a confusing error `The data in line <line_num> of dataset <path/to/dataset.jsonl> is incorrectly formatted.Conversation must start with a user message or system message`, even though the messages start with `system`.

The issues arises because `finetune/data/tokenize.py` passes the messages without the system prompt to the `mistral_common/protocol/instruct/validator.py` script, which then throws the error because of if-condition in func `_validate_message_list_structure` on line 253.

In many training scenarios, the system prompt is directly followed by the model/assistant message and that is the end of the conversation. The current validation flags this as being an erroneous structure, though it should be a valid one. To fix this inconsistency, this PR change adds the system prompt back into the messages for the validation step to fix this issue, and removes it right after the checks.