### PR TITLE
Fix a mis-aligned else that causes a crash

### DIFF
--- a/utils/validate_data.py
+++ b/utils/validate_data.py
@@ -110,7 +110,7 @@ def get_train_stats(
             model_id = "mistral-large-latest"
         elif params_config["dim"] == 5120:
             model_id = "open-mistral-nemo"
-	else:
+        else:
             raise ValueError("Provided model folder seems incorrect.")
     else:
         model_id = train_args.model_id_or_path


### PR DESCRIPTION
Fixes an issue introduced in the commit `984ca2dc` where the `else` is misaligned causing the following crash when running data validation tool.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 159, in _get_module_details
  File "<frozen importlib._bootstrap_external>", line 1074, in get_code
  File "<frozen importlib._bootstrap_external>", line 1004, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/ec2-user/workspace/mistral/mistral-finetune/utils/validate_data.py", line 113
    else:
TabError: inconsistent use of tabs and spaces in indentation
```