### PR TITLE
Fixed issues with mistral-common update

### DIFF
--- a/finetune/checkpointing.py
+++ b/finetune/checkpointing.py
@@ -6,10 +6,8 @@ from typing import Dict, List, Optional, Union
 
 import safetensors.torch
 import torch
-from mistral_common.tokens.tokenizers.sentencepiece import (
-    InstructTokenizerBase,
-    SentencePieceTokenizer,
-)
+from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
+from mistral_common.tokens.tokenizers.instruct import InstructTokenizerBase
 from torch.distributed import barrier
 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel
 

--- a/finetune/data/data_loader.py
+++ b/finetune/data/data_loader.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Any, Iterator, List, Optional
 
 import numpy as np
-from mistral_common.tokens.tokenizers.sentencepiece import InstructTokenizerBase
+from mistral_common.tokens.tokenizers.instruct import InstructTokenizerBase
 
 from .args import DataArgs
 from .dataset import build_dataset

--- a/finetune/data/dataset.py
+++ b/finetune/data/dataset.py
@@ -12,7 +12,7 @@ from mistral_common.protocol.instruct.messages import (
     FinetuningAssistantMessage,
     SystemMessage,
 )
-from mistral_common.tokens.tokenizers.sentencepiece import InstructTokenizerBase
+from mistral_common.tokens.tokenizers.instruct import InstructTokenizerBase
 
 from finetune.distributed import get_rank
 

--- a/finetune/data/tokenize.py
+++ b/finetune/data/tokenize.py
@@ -22,7 +22,7 @@ from mistral_common.protocol.instruct.validator import (
 )
 from mistral_common.tokens.instruct.request import InstructRequest
 from mistral_common.tokens.tokenizers.base import Tokenizer
-from mistral_common.tokens.tokenizers.sentencepiece import InstructTokenizerBase
+from mistral_common.tokens.tokenizers.instruct import InstructTokenizerBase
 
 from .exceptions import (
     ConversationFormatError,
@@ -177,7 +177,7 @@ def build_instruct_sample(data: Dict[str, Any]) -> TrainingInstructSample:
 
     # validate created messages
     validator = MistralRequestValidatorV3(ValidationMode.finetuning)
-    validator.validate_messages(messages)
+    validator.validate_messages(messages, False)
     validator._validate_tools(available_tools or [])
 
     # whether to train only on last assistant message
@@ -328,7 +328,7 @@ def tokenize_instruct(
             message = maybe_remove_call_id(message, is_last_message=is_last_message)
 
             curr_tokens = instruct_tokenizer.encode_assistant_message(
-                message, is_before_last_user_message=False
+                message, is_before_last_user_message=False, continue_message=False
             )
 
             is_weighted = message.weight is None or message.weight == 1


### PR DESCRIPTION
I think this fixes Issue #110 . 

In one commit of mistral-common, they moved the InstructTokenizerBase to another file (see commit mistral-ai/mistral-common@2c9f1762f8824e5d821840414ecb1b9e5267ffb3).
This required a fix in the import of the InstructTokenizerBase in two files
1.  In File "mistral-finetune/finetune/data/dataset.py", line 15, change
    from mistral_common.tokens.tokenizers.sentencepiece import InstructTokenizerBase to
    from mistral_common.tokens.tokenizers.instruct import InstructTokenizerBase
2. In File "mistral-finetune/finetune/data/tokenize.py", line 25, change
    from mistral_common.tokens.tokenizers.sentencepiece import InstructTokenizerBase to
    from mistral_common.tokens.tokenizers.instruct import InstructTokenizerBase

Also, afterward, I received another error concerning the updated mistral-common, which I fixed by editing
3. In File "mistral-finetune/finetune/data/tokenize.py", line 180, change validator.validate_messages(messages) to validator.validate_messages(messages, False)
4. In File "mistral-finetune/finetune/data/tokenize.py", line 330, change curr_tokens = instruct_tokenizer.encode_assistant_message(message, is_before_last_user_message=False) to curr_tokens = instruct_tokenizer.encode_assistant_message(message, is_before_last_user_message=False, continue_message=False)

With fixed 3 and 4, I compared the old code of mistral-common to the new code, and I am confident that this is the intended behavior.
