### PR TITLE
feat: add Dockerfile for containerized fine-tuning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+dist
+build
+.mypy_cache
+.ruff_cache
+.pytest_cache
+tutorials/
+tests/
+*.md
+!README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Dockerfile for Mistral AI Fine-Tuning
+# Supports LoRA fine-tuning of Mistral models with GPU acceleration
+#
+# Build:
+#   docker build -t mistral-finetune .
+#
+# Run (single GPU):
+#   docker run --gpus all -v /path/to/data:/data -v /path/to/model:/model \
+#     mistral-finetune --config /data/config.yaml
+#
+# Run (multi-GPU with torchrun):
+#   docker run --gpus all -v /path/to/data:/data -v /path/to/model:/model \
+#     --entrypoint torchrun mistral-finetune \
+#     --nproc_per_node=4 /app/train.py --config /data/config.yaml
+
+FROM pytorch/pytorch:2.2.0-cuda12.1-cudnn8-devel
+
+# Prevent interactive prompts during build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies (cached layer)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Default entrypoint for single-GPU training
+ENTRYPOINT ["python", "-m", "train"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ cd mistral-finetune
 pip install -r requirements.txt
 ```
 
+## Docker
+
+You can use the provided Dockerfile to avoid manual environment setup:
+
+```bash
+# Build the image
+docker build -t mistral-finetune .
+
+# Run single-GPU fine-tuning
+docker run --gpus all \
+  -v /path/to/data:/data \
+  -v /path/to/model:/model \
+  mistral-finetune --config /data/config.yaml
+
+# Run multi-GPU fine-tuning with torchrun
+docker run --gpus all \
+  --entrypoint torchrun \
+  mistral-finetune \
+  --nproc_per_node=4 /app/train.py --config /data/config.yaml
+```
+
+> **Note:** The Docker image is based on `pytorch/pytorch:2.2.0-cuda12.1-cudnn8-devel` and requires NVIDIA GPU with CUDA 12.1+ support. Mount your training data and model weights as volumes.
+
 ## Model download
 
 We recommend fine-tuning one of the official Mistral models which you can download here:


### PR DESCRIPTION
## Summary

Adds a `Dockerfile` for containerized fine-tuning, addressing recurring environment setup issues (#98, #109, #92).

### What's included
- **Dockerfile**: Based on `pytorch/pytorch:2.2.0-cuda12.1-cudnn8-devel` with all dependencies pre-installed
- **.dockerignore**: Excludes unnecessary files from the build context
- **README update**: Docker usage instructions (single-GPU and multi-GPU)

### Usage

```bash
# Build
docker build -t mistral-finetune .

# Single GPU
docker run --gpus all -v /data:/data -v /model:/model mistral-finetune --config /data/config.yaml

# Multi-GPU (torchrun)
docker run --gpus all --entrypoint torchrun mistral-finetune \
  --nproc_per_node=4 /app/train.py --config /data/config.yaml
```

### Design decisions
- **Base image**: `pytorch/pytorch:2.2.0-cuda12.1-cudnn8-devel` matches the pinned `torch==2.2` requirement and includes CUDA development headers needed for xformers compilation
- **Volume mounts**: Training data and model weights are mounted at runtime (not baked into the image) for flexibility
- **Entrypoint**: Defaults to `python -m train` for simplicity; override with `torchrun` for distributed training

### Related issues
- Partially addresses #98 (environment setup issues)
- Partially addresses #109 (installation difficulties)