### PR TITLE
ci: add lint and type check workflow

### DIFF
--- a/.github/lint-workflow.yml
+++ b/.github/lint-workflow.yml
@@ -1,0 +1,44 @@
+name: Lint & Type Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('requirements.dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Check formatting with black
+        run: black --check .
+
+      - name: Type check with mypy
+        run: mypy --ignore-missing-imports .


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow for automated code quality checks.

### What it does
- **ruff**: Linting (already configured in `pyproject.toml`)
- **black**: Format checking (already configured in `pyproject.toml`)
- **mypy**: Type checking (already configured in `pyproject.toml`)

### Important: File Placement

The workflow file is placed at `.github/lint-workflow.yml` instead of `.github/workflows/lint.yml` due to GitHub token scope limitations during PR creation. **To activate the workflow, simply move the file:**

```bash
mkdir -p .github/workflows
mv .github/lint-workflow.yml .github/workflows/lint.yml
```

Alternatively, a maintainer with the `workflow` scope can move the file directly.

### Why
The project has `ruff`, `black`, `mypy`, and `pytest` configured in `pyproject.toml` and listed in `requirements.dev.txt`, but no CI automation to enforce them. This workflow runs the lint checks on every push to `main` and on pull requests.

### What's NOT included (by design)
- **pytest**: Tests require a GPU and a `DUMMY_MODEL` path, so they cannot run on free GitHub-hosted runners. A GPU-enabled test job could be added later with self-hosted runners.

### Configuration
- Python 3.10 (matches the project's minimum supported version)
- Pip dependency caching for faster CI runs
- Triggers: push to `main` + all pull requests to `main`